### PR TITLE
Hide all shorts in search page for mobile site

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -52,3 +52,4 @@ m.youtube.com##ytm-chip-cloud-chip-renderer:has(.yt-core-attributed-string:has-t
 
 ! Hide shorts sections on search page
 m.youtube.com##grid-shelf-view-model:has(ytm-shorts-lockup-view-model)
+m.youtube.com##ytm-video-with-context-renderer:has(.big-shorts-singleton)

--- a/list.txt
+++ b/list.txt
@@ -51,4 +51,4 @@ m.youtube.com##ytm-reel-shelf-renderer:has(.reel-shelf-title-wrapper .yt-core-at
 m.youtube.com##ytm-chip-cloud-chip-renderer:has(.yt-core-attributed-string:has-text(/^Shorts$/i))
 
 ! Hide shorts sections on search page
-m.youtube.com##ytm-reel-shelf-renderer:has(ytm-shorts-lockup-view-model)
+m.youtube.com##grid-shelf-view-model:has(ytm-shorts-lockup-view-model)


### PR DESCRIPTION
Hide shorts section on search page for mobile site.
<img width="1174" height="951" alt="Screenshot 2026-03-26 230910" src="https://github.com/user-attachments/assets/f43188d5-4c05-48ab-8ff3-b9d20b208b36" />

Hide shorts appear as video item in search page (this should completely resolve #6 for mobile site).
<img width="1313" height="951" alt="Screenshot 2026-03-27 084815" src="https://github.com/user-attachments/assets/aa1d02e4-c2ec-4758-93f3-d96b3d8fce0b" />