### PR TITLE
Hide shorts inside video list in search page

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -12,6 +12,7 @@ www.youtube.com##ytd-rich-section-renderer:has(a[href^="/shorts/"])
 
 ! Hide on search page
 www.youtube.com##ytd-search grid-shelf-view-model:has(a[href^="/shorts/"])
+www.youtube.com##ytd-search ytd-video-renderer:has(a[href^="/shorts/"])
 ! Hide shorts search tab of search results 
 www.youtube.com##yt-chip-cloud-chip-renderer:has(*:has-text(/^Shorts$/i))
 


### PR DESCRIPTION
Hide shorts appears as video item in video list.
Fix #8.
