### PR TITLE
Hide shorts section on subscription page

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -54,3 +54,6 @@ m.youtube.com##ytm-chip-cloud-chip-renderer:has(.yt-core-attributed-string:has-t
 ! Hide shorts sections on search page
 m.youtube.com##grid-shelf-view-model:has(ytm-shorts-lockup-view-model)
 m.youtube.com##ytm-video-with-context-renderer:has(.big-shorts-singleton)
+
+! Hide shorts section on subscriptions page
+m.youtube.com##ytm-reel-shelf-renderer:has(ytm-shorts-lockup-view-model)


### PR DESCRIPTION
I accidentally deleted this rule from previous PR as it was described to hide shorts on search page. Maybe youtube used this element for both search page and subscription page in the past and now only subscription page use this element. Just find the regression recently when I clean up my filter list and update from this repo.

<img width="1143" height="954" alt="Screenshot 2026-04-22 185505" src="https://github.com/user-attachments/assets/6cac808b-fdc2-43a2-833c-cf20da8aa87d" />
